### PR TITLE
CD-7298 Agentic - Add Ability for "Rules Inclusion List"

### DIFF
--- a/plugin-api/src/main/java/org/sonar/api/rules/Rule.java
+++ b/plugin-api/src/main/java/org/sonar/api/rules/Rule.java
@@ -86,6 +86,7 @@ public class Rule {
   private Date updatedAt;
   private String tags;
   private String systemTags;
+  private boolean aiCodeFixEnabled = false;
 
   private Rule() {
   }
@@ -378,6 +379,15 @@ public class Rule {
     return this;
   }
 
+  public boolean getAiCodeFixEnabled() {
+    return aiCodeFixEnabled;
+  }
+
+  public Rule setAiCodeFixEnabled(boolean aiCodeFixEnabled) {
+    this.aiCodeFixEnabled = aiCodeFixEnabled;
+    return this;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (!(obj instanceof Rule)) {
@@ -411,6 +421,7 @@ public class Rule {
       .append("plugin", pluginName)
       .append("severity", priority)
       .append("isTemplate", isTemplate())
+      .append("aiCodeFixEnabled", aiCodeFixEnabled)
       .append("status", status)
       .append("language", language)
       .append("template", template)


### PR DESCRIPTION
Add the ability for the backend to maintain a "Rules Inclusion List" that determines which rules are eligible for AI-assisted fixes. This list will later be exposed to the UI, enabling users to filter and view only the issues relevant for possible AI fixes.

Hypothesis
If we implement a backend-driven Rules Inclusion List that defines AI-fix eligible rules, then:

The AI service will operate only on validated, high-confidence rules.

Users will see fewer false or irrelevant AI suggestions.

The UI can provide a clear filter to highlight issues that are AI-fixable, improving trust and adoption.