### PR TITLE
CD-7811 migrate from javax.servlet to jakarta.servlet

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=org.sonarsource.api.plugin
-version=10.14-CODESCAN
+version=10.15-CODESCAN
 description=Plugin API for CodeScan
 org.gradle.jvmargs=-Xmx2048m

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   implementation project(':check-api')
 
   compileOnly libs.jsr305
-  compileOnly libs.javax.servlet.api
+  compileOnly libs.jakarta.servlet.api
 
   testImplementation libs.junit4
   testImplementation libs.junit5

--- a/plugin-api/src/main/java/org/sonar/api/security/Authenticator.java
+++ b/plugin-api/src/main/java/org/sonar/api/security/Authenticator.java
@@ -20,7 +20,7 @@
 package org.sonar.api.security;
 
 import javax.annotation.Nullable;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.sonar.api.ExtensionPoint;
 import org.sonar.api.server.ServerSide;
 import org.sonar.api.server.http.HttpRequest;

--- a/plugin-api/src/main/java/org/sonar/api/security/ExternalGroupsProvider.java
+++ b/plugin-api/src/main/java/org/sonar/api/security/ExternalGroupsProvider.java
@@ -21,7 +21,7 @@ package org.sonar.api.security;
 
 import java.util.Collection;
 import javax.annotation.CheckForNull;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.sonar.api.server.http.HttpRequest;
 
 /**

--- a/plugin-api/src/main/java/org/sonar/api/security/ExternalUsersProvider.java
+++ b/plugin-api/src/main/java/org/sonar/api/security/ExternalUsersProvider.java
@@ -20,7 +20,7 @@
 package org.sonar.api.security;
 
 import javax.annotation.Nullable;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.sonar.api.server.http.HttpRequest;
 
 /**

--- a/plugin-api/src/main/java/org/sonar/api/server/authentication/BaseIdentityProvider.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/authentication/BaseIdentityProvider.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.api.server.authentication;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.sonar.api.server.http.HttpRequest;
 import org.sonar.api.server.http.HttpResponse;
 

--- a/plugin-api/src/main/java/org/sonar/api/server/authentication/OAuth2IdentityProvider.java
+++ b/plugin-api/src/main/java/org/sonar/api/server/authentication/OAuth2IdentityProvider.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.api.server.authentication;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.sonar.api.server.http.HttpRequest;
 import org.sonar.api.server.http.HttpResponse;
 

--- a/plugin-api/src/main/java/org/sonar/api/web/ServletFilter.java
+++ b/plugin-api/src/main/java/org/sonar/api/web/ServletFilter.java
@@ -36,7 +36,7 @@ import org.sonar.api.server.ServerSide;
 @ServerSide
 @ExtensionPoint
 @Deprecated(forRemoval = true, since = "9.16")
-public abstract class ServletFilter implements javax.servlet.Filter {
+public abstract class ServletFilter implements jakarta.servlet.Filter {
 
   /**
    * Override to change URL. Default is /*

--- a/plugin-api/src/test/java/org/sonar/api/security/ExternalGroupsProviderTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/security/ExternalGroupsProviderTest.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.Test;
 import org.sonar.api.server.http.HttpRequest;
 

--- a/plugin-api/src/test/java/org/sonar/api/security/ExternalUsersProviderTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/security/ExternalUsersProviderTest.java
@@ -20,7 +20,7 @@
 package org.sonar.api.security;
 
 import com.google.common.base.Preconditions;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.Test;
 import org.sonar.api.server.http.HttpRequest;
 

--- a/plugin-api/src/test/java/org/sonar/api/web/ServletFilterTest.java
+++ b/plugin-api/src/test/java/org/sonar/api/web/ServletFilterTest.java
@@ -19,10 +19,10 @@
  */
 package org.sonar.api.web;
 
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@ dependencyResolutionManagement {
       library('guava', 'com.google.guava:guava:31.1-jre')
       library('gson', 'com.google.code.gson:gson:2.11.0')
       library('jsr305', 'com.google.code.findbugs:jsr305:3.0.2')
-      library('javax-servlet-api', 'javax.servlet:javax.servlet-api:3.1.0')
+      library('jakarta-servlet-api', 'jakarta.servlet:jakarta.servlet-api:6.1.0')
       library('junit4', 'junit:junit:4.13.2')
       library('junit5', 'org.junit.jupiter:junit-jupiter-api:5.10.3')
       library('jupiter-engine', 'org.junit.jupiter:junit-jupiter-engine:5.10.3')


### PR DESCRIPTION
As part of upgrading Sonarqube to use Tomcat version 11, there are some dependencies to this project that generate compiler error. The cause is that this project uses package `javax.servlet`. This should be migrated to `jakarta.servlet`.

This PR focuses on migration package `javax.servlet` to `jakarta.servlet` and related changes from this migration.