### PR TITLE
CD-8286 | Enable Configurable Cross-File Analysis in IDE Extension

### DIFF
--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/InputFile.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/InputFile.java
@@ -209,11 +209,11 @@ public interface InputFile extends IndexedFile {
   String toString();
 
   /**
-   * Dependency files of this file. If not null, files contain at least one usage of a method defined in this file.
+   * Reference files of this file. If not null, files contain at least one usage of a method defined in this file.
    *
-   * @return the dependency files, or {@code null} if none
+   * @return the reference files, or {@code null} if none
    */
-  default List<InputFile> getDependencyFiles() {
+  default List<InputFile> getReferenceFiles() {
     return null;
   }
 }

--- a/plugin-api/src/main/java/org/sonar/api/batch/fs/InputFile.java
+++ b/plugin-api/src/main/java/org/sonar/api/batch/fs/InputFile.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.util.List;
 import javax.annotation.CheckForNull;
 import org.sonar.api.batch.sensor.SensorDescriptor;
 
@@ -206,4 +207,13 @@ public interface InputFile extends IndexedFile {
    */
   @Override
   String toString();
+
+  /**
+   * Dependency files of this file. If not null, files contain at least one usage of a method defined in this file.
+   *
+   * @return the dependency files, or {@code null} if none
+   */
+  default List<InputFile> getDependencyFiles() {
+    return null;
+  }
 }


### PR DESCRIPTION
**As discussed with the product team, cross-file analysis may impact performance and memory usage 
while running.** 



Currently, the IDE extension performs file-wise analysis, meaning only the file that is opened or modified gets analyzed. This approach causes inaccurate or missed violations for rules that require context across multiple files (e.g., AvoidSOQLInLoops, where validation may depend on logic spread across classes or triggers).

To address this limitation:

Introduce a Project Setting in the CodeScan apllication:

Cross-File Analysis Control (default: Disabled to preserve performance).

IDE Cross file analysis-20260303-064801.png
 

Identify and tag all rules that require cross-file or full-project traversal.

If Cross-File Analysis is Enabled:

The engine should traverse all relevant files when evaluating tagged rules.

However, only violations related to the currently opened file should be displayed in the IDE.

Violations found in other files during traversal should not be shown in the IDE panel.

Scan Optimization Rules:

If a class file is opened → analyze all class files first, then remaining files if needed.

If cross-file-required rules are not present in the active Quality Profile, skip full project traversal entirely.

Ensure traversal is rule-aware and profile-aware to prevent unnecessary scanning.

Hypothesis
If cross-file analysis is made configurable and rule-aware, the IDE extension will:

Provide more accurate detection for interdependent rules.

Maintain performance efficiency by scanning only when required.

Prevent developer distraction by limiting displayed violations to the active file.

Reduce unnecessary full-project scans when cross-file rules are not active in the Quality Profile.

Value / Purpose
Improved Rule Accuracy – Enables correct evaluation of cross-dependent rules like AvoidSOQLInLoops.

Developer Experience – Keeps IDE feedback focused on the current file, avoiding noise.

Performance Optimization – Conditional traversal reduces unnecessary scans.

Acceptance Criteria


Introduce a Project Setting in the CodeScan apllication:

Cross-File Analysis Control (default: Disabled to preserve performance).

IDE Cross file analysis-20260303-064801.png
Add Note: “Note: After enabling or disabling this setting, CodeScan project bindings must be updated again in the IDE.“

Identify and tag all rules that require cross-file or full-project traversal.

If Cross-File Analysis is Enabled:

The engine should traverse all relevant files when evaluating tagged rules.

However, only violations related to the currently opened file should be displayed in the IDE.

Violations found in other files during traversal should not be shown in the IDE panel.

Scan Optimization Rules:

If a class file is opened → analyze all class files first, then remaining files if needed.

If cross-file-required rules are not present in the active Quality Profile, skip full project traversal entirely.

Ensure traversal is rule-aware and profile-aware to prevent unnecessary scanning.